### PR TITLE
uec: quick fix: load balancing timeout feedback

### DIFF
--- a/htsim/sim/uec.cpp
+++ b/htsim/sim/uec.cpp
@@ -2085,6 +2085,7 @@ mem_b UecSrc::sendNewPacket(const Route& route) {
 
     uint16_t ev = _mp->nextEntropy(_highest_sent, (uint64_t)_cwnd/_mss);
     p->set_pathid(ev);
+    hashmap_entropy[p->epsn()] = ev;
     p->flow().logTraffic(*p, *this, TrafficLogger::PKT_CREATESEND);
 
     if (_backlog == 0 || (_receiver_based_cc && _credit <= 0) || ( _sender_based_cc &&  (_in_flight + full_pkt_size) >= _cwnd )) 
@@ -2130,6 +2131,7 @@ mem_b UecSrc::sendRtxPacket(const Route& route) {
 
     uint16_t ev = _mp->nextEntropy(_highest_sent, (uint64_t)_cwnd/_mss);
     p->set_pathid(ev);
+    hashmap_entropy[p->epsn()] = ev;
     p->flow().logTraffic(*p, *this, TrafficLogger::PKT_CREATESEND);
 
     createSendRecord(seq_no, full_pkt_size);
@@ -2330,7 +2332,7 @@ void UecSrc::rtxTimerExpired() {
 
     // Trigger multipathing feedback for timeout. Unless we save EVs on the sender per packet, we will 
     // not be able to recover the original timed-out ev.
-    _mp->processEv(UecMultipath::UNKNOWN_EV, UecMultipath::PATH_TIMEOUT);
+    _mp->processEv(hashmap_entropy[seqno], UecMultipath::PATH_TIMEOUT);
 
     // update flightsize?
 

--- a/htsim/sim/uec.h
+++ b/htsim/sim/uec.h
@@ -215,6 +215,8 @@ public:
     enum Sender_CC { DCTCP, NSCC, CONSTANT};
     static Sender_CC _sender_cc_algo;
 
+    std::unordered_map<uint64_t, uint16_t> hashmap_entropy;
+
     static bool _disable_quick_adapt;
     static uint8_t _qa_gate;
 


### PR DESCRIPTION
Hello,

I am a master's student hoping to learn a bit about Datacenter Networks.
I have followed [Costin Raiciu's Sigcomm2025 tutorial](https://github.com/craiciu/sigcomm25-ethernet-ai-tutorial).

But found the performance of bitmap to be unrealistically poor.

So I applied this fix.
Which was copied from the [REPS repo](https://github.com/tommasobo/REPS_EuroSys_Artifact/blob/b751588745b57e8264ce22d9a40df67bdedd62c0/htsim/sim/uec.cpp).

Previous implementation did not save information about outgoing EVs. So it hardcoded `UNKNOWN_EV` as the default EV on timeout. Being the first entry in a C++ enum, it was thus implicitly cast to zero.

What are your thoughts on this?
Should this PR be made to the UET htsim repo?

## Impact on performance

I've made two graphs plotting the performance of this PR.
The testing scenario was:

- topo: `topologies/leaf_spine_1024.topo`
- tm: `connection_matrices/perm_1024n_1024c_0u_2000000b.cm`
- seeds: `[117714526, 2022515459, -469739775, -1705427760, -1069707021, -1228084970, 902897377, -1458612024, -120450033, 354708325]`

![compare_patch](https://github.com/user-attachments/assets/d848800a-f800-4547-a531-9d344508b819)
![compare_patch2](https://github.com/user-attachments/assets/6a9a3742-c7de-4879-83da-c815ccd28a6d)
